### PR TITLE
Allow array of expressions in dimension filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ return Analytics::get();
 
 `setDimensionFilter` accept 3 parameters. First parameter get the dimension name in which you want to filter analytics data. Second parameter get the [operator](https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#operator) (REGEXP, BEGINS_WITH, ENDS_WITH and more) you want. Third parameter get the expression. For example if you want to get all analytics data in which the page path include `play` or `simple` words you can use: `Analytics::setDimensionFilter('ga:pagePath', 'REGEXP', '(\/play\/|\/simple\/)');`
 
-If you want to get analytics data for multiple pages in a single request, you can use the 'IN_LIST' operator and pass an array of paths as the third parameter. E.g. `Analytics::setDimensionFilter('ga:pagePath', 'IN_LIST', ['/i-want-data-for-this-path', '/and/this-path-too']);`
+If you want to get analytics data for multiple pages in a single request by their exact paths, you can use the 'IN_LIST' operator and pass an array of paths as the third parameter. E.g. 
+`Analytics::setDimensionFilter('ga:pagePath', 'IN_LIST', ['/i-want-data-for-this-path', '/and/this-path-too']);`
 
 `setOrder` method accept 3 parameters. First parameter get the name in which you want to order the data. Second get [OrderType](https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#ordertype) usually `VALUE`. Third get the [SortOrder](https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#sortorder) usually `ASCENDING` or `DESCENDING`.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Analytics::setDateRange('2016-10-01', '2016-11-25');
 Analytics::setMaxResults(20);
 Analytics::setMetrics(['ga:entrances', 'ga:pageviews', 'ga:bounceRate']);
 Analytics::setDimension(['ga:pagePath', 'ga:pageTitle']);
-Analytics::setDimensionFilter('ga:pagePath', 'REGEXP', 'i-want-to-get-all-data-that-has-this-page-path');
+Analytics::setDimensionFilter('ga:pagePath', 'REGEXP', '/i-want-to-get-all-data-that-has-this-page-path');
 Analytics::setOrder('ga:pageviews', 'VALUE', 'DESCENDING');
 return Analytics::get();
 ```
@@ -75,6 +75,8 @@ return Analytics::get();
 `setMetrics` and `setDimension` methods accept an array containing the wanted metrics and dimension. Available [metrics and dimensions](https://developers.google.com/analytics/devguides/reporting/core/dimsmets)
 
 `setDimensionFilter` accept 3 parameters. First parameter get the dimension name in which you want to filter analytics data. Second parameter get the [operator](https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#operator) (REGEXP, BEGINS_WITH, ENDS_WITH and more) you want. Third parameter get the expression. For example if you want to get all analytics data in which the page path include `play` or `simple` words you can use: `Analytics::setDimensionFilter('ga:pagePath', 'REGEXP', '(\/play\/|\/simple\/)');`
+
+If you want to get analytics data for multiple pages in a single request, you can use the 'IN_LIST' operator and pass an array of paths as the third parameter. E.g. `Analytics::setDimensionFilter('ga:pagePath', 'IN_LIST', ['/i-want-data-for-this-path', '/and/this-path-too']);`
 
 `setOrder` method accept 3 parameters. First parameter get the name in which you want to order the data. Second get [OrderType](https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#ordertype) usually `VALUE`. Third get the [SortOrder](https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#sortorder) usually `ASCENDING` or `DESCENDING`.
 

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -59,7 +59,7 @@ class Analytics implements \Panakour\Analytics\Contracts\Analytics
         ];
     }
 
-    public function setDimensionFilter(string $dimensionName, string $operator, string $expression)
+    public function setDimensionFilter(string $dimensionName, string $operator, $expression)
     {
         $this->analytics[] = [
             'method'     => 'setDimensionFilter',

--- a/src/Contracts/Analytics.php
+++ b/src/Contracts/Analytics.php
@@ -18,7 +18,7 @@ interface Analytics
 
     public function setDimension(array $dimension);
 
-    public function setDimensionFilter(string $dimensionName, string $operator, string $expression);
+    public function setDimensionFilter(string $dimensionName, string $operator, $expression);
 
     public function setOrder(string $fieldName, string $orderType, string $sortType);
 }

--- a/src/Core/DimensionFilter.php
+++ b/src/Core/DimensionFilter.php
@@ -36,7 +36,7 @@ class DimensionFilter
         $this->dimensionFilter->setDimensionName($dimensionName);
     }
 
-    private function setExpression(string $expression)
+    private function setExpression($expression)
     {
         $this->dimensionFilter->setExpressions($expression);
     }


### PR DESCRIPTION
Hi there - just wanted to say thanks very much for creating this package! It really is an easy and simple solution to interfacing with Google's latest v4 API.

I've just made a minor adjustment for my use case, which is to remove the type hinting for the expression parameter when setting the dimension filter, thus enabling us to optionally pass an array for filtering with the 'IN_LIST' operator.  

More info here: https://developers.google.com/analytics/devguides/reporting/core/v4/rest/v4/reports/batchGet#DimensionFilterClause