### PR TITLE
Allow get data without specify dimensions.

### DIFF
--- a/src/Core/Renderable.php
+++ b/src/Core/Renderable.php
@@ -27,9 +27,11 @@ class Renderable
                 $dimensions = $row->getDimensions();
                 $metrics = $row->getMetrics();
 
-                for ($i = 0; $i < count($dimensionHeaders) && $i < count($dimensions); $i++) {
-                    $dimensionName = $dimensionHeaders[$i];
-                    $myReport[$rowIndex][$dimensionName] = $dimensions[$i];
+                if($dimensionHeaders && count($dimensionHeaders)) {
+                    for ($i = 0; $i < count($dimensionHeaders) && $i < count($dimensions); $i++) {
+                        $dimensionName = $dimensionHeaders[$i];
+                        $myReport[$rowIndex][$dimensionName] = $dimensions[$i];
+                    }
                 }
 
                 for ($j = 0; $j < count($metricHeaders) && $j < count($metrics); $j++) {


### PR DESCRIPTION
Sometimes we want data without specify dimension. Eg. all users and sessions from specify date range.

`Array
(
    [0] => Array
        (
            [ga:users] => 92
            [ga:sessions] => 278
            [ga:sessionsPerUser] => 3.0217391304347827
            [ga:avgSessionDuration] => 471.58273381294964
            [ga:pageviews] => 3287
            [ga:pageviewsPerSession] => 11.823741007194245
        )
)`